### PR TITLE
Fix potential bug when cancelling requests in `didEndDisplaying cell`…

### DIFF
--- a/EssentialApp2/EssentialApp2Tests/FeedUIIntegrationTests.swift
+++ b/EssentialApp2/EssentialApp2Tests/FeedUIIntegrationTests.swift
@@ -69,6 +69,24 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+        
+        sut.simulateAppearance()
+        sut.tableView.frame = CGRect(x: 0, y: 0, width: 390, height: 400)
+        
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+        
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+        
+        RunLoop.main.run(until: .now + 1)
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage()
         let (sut, loader) = makeSUT()

--- a/EssentialApp2/EssentialApp2Tests/Helpers/FeedUIIntegrationTests+Asserts.swift
+++ b/EssentialApp2/EssentialApp2Tests/Helpers/FeedUIIntegrationTests+Asserts.swift
@@ -16,6 +16,9 @@ extension FeedUIIntegrationTests {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        sut.tableView.layoutIfNeeded()
+        RunLoop.main.run(until: Date())
+        
         guard sut.numberOfRenderedFeedImageView() == feed.count else {
             return XCTFail(
                 "Expected \(feed.count) rendered feed image view(s), but got \(sut.numberOfRenderedFeedImageView()) instead",

--- a/EssentialFeed2/EssentialFeed2iOS/Feed UI/Controllers/FeedViewController.swift
+++ b/EssentialFeed2/EssentialFeed2iOS/Feed UI/Controllers/FeedViewController.swift
@@ -21,6 +21,8 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     
     var delegate: FeedViewControllerDelegate?
     
+    private var loadingControllers: [IndexPath: FeedImageCellController] = [:]
+    
     private var tableModel = [FeedImageCellController]() {
         didSet { tableView.reloadData() }
     }
@@ -54,6 +56,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -74,7 +77,7 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public override func tableView(_ tableView: UITableView, didEndDisplaying cell: UITableViewCell, forRowAt indexPath: IndexPath) {
-        removeCellController(forRowAt: indexPath)
+        cancelCellController(forRowAt: indexPath)
     }
     
     public func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
@@ -84,14 +87,16 @@ final public class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func tableView(_ tableView: UITableView, cancelPrefetchingForRowsAt indexPaths: [IndexPath]) {
-        indexPaths.forEach(removeCellController)
+        indexPaths.forEach(cancelCellController)
     }
     
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
-    private func removeCellController(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+    private func cancelCellController(forRowAt indexPath: IndexPath) {
+        loadingControllers[indexPath]?.cancelLoad()
     }
 }


### PR DESCRIPTION
… method. Method could be invoked after reloadData, so we either crash or cancel wrong models